### PR TITLE
Update php repo

### DIFF
--- a/manifests/app/cachet.pp
+++ b/manifests/app/cachet.pp
@@ -60,7 +60,7 @@ define uhosting::app::cachet (
     'static-skip-ext' => '.php',
     'check-static'    => $webroot,
     'chdir'           => $webroot,
-    'cron2'           => "minute=-10,unique=1 /usr/bin/php5 ${webroot}/artisan schedule:run 1>/dev/null",
+    'cron2'           => "minute=-10,unique=1 /usr/bin/php5.5 ${webroot}/artisan schedule:run 1>/dev/null",
     'php-docroot'     => '',
     'php-allowed-ext' => '.php',
     'php-index'       => 'index.php',
@@ -111,7 +111,7 @@ define uhosting::app::cachet (
 
   ## Pre-requisits
 
-  #ensure_packages([ 'php5-curl',
-  #                  'php5-gd'])
+  #ensure_packages([ 'php5.5-curl',
+  #                  'php5.5-gd'])
 
 }

--- a/manifests/app/magento.pp
+++ b/manifests/app/magento.pp
@@ -67,7 +67,7 @@ define uhosting::app::magento (
 
   include uhosting::profiles::php
   include uhosting::profiles::supervisord
-  $fpm_socket = "/var/lib/uhosting/php5-fpm-${name}.sock"
+  $fpm_socket = "/var/lib/uhosting/php5.5-fpm-${name}.sock"
 
   # PHP-FPM pool
   $_php_values = {
@@ -242,12 +242,12 @@ define uhosting::app::magento (
 
   ## Pre-requisits
 
-  ensure_packages([ 'php5-mysql',
+  ensure_packages([ 'php5.5-mysql',
                     'php-crypt-gpg',
-                    'php5-curl',
-                    'php5-mcrypt',
-                    'php5-apcu',
-                    'php5-gd'])
+                    'php5.5-curl',
+                    'php5.5-mcrypt',
+                    'php5.5-apcu',
+                    'php5.5-gd'])
 
 
 }

--- a/manifests/app/magento.pp
+++ b/manifests/app/magento.pp
@@ -67,7 +67,7 @@ define uhosting::app::magento (
 
   include uhosting::profiles::php
   include uhosting::profiles::supervisord
-  $fpm_socket = "/var/lib/uhosting/php5.5-fpm-${name}.sock"
+  $fpm_socket = "/var/lib/uhosting/php-fpm-${name}.sock"
 
   # PHP-FPM pool
   $_php_values = {

--- a/manifests/app/owncloud.pp
+++ b/manifests/app/owncloud.pp
@@ -173,12 +173,12 @@ define uhosting::app::owncloud (
 
   ## Pre-requisits
 
-  ensure_packages([ 'php5-curl',
-                    'php5-intl',
-                    'php5-xmlrpc',
-                    'php5-xsl',
-                    'php5-apcu',
-                    'php5-gd'])
+  ensure_packages([ 'php5.5-curl',
+                    'php5.5-intl',
+                    'php5.5-xmlrpc',
+                    'php5.5-xsl',
+                    'php5.5-apcu',
+                    'php5.5-gd'])
 
   ## If needed install application package
 

--- a/manifests/app/wordpress.pp
+++ b/manifests/app/wordpress.pp
@@ -58,7 +58,7 @@ define uhosting::app::wordpress (
 
   include uhosting::profiles::php
   include uhosting::profiles::supervisord
-  $fpm_socket = "/var/lib/uhosting/php5.5-fpm-${name}.sock"
+  $fpm_socket = "/var/lib/uhosting/php-fpm-${name}.sock"
 
   # PHP-FPM pool
   $_php_values = {

--- a/manifests/app/wordpress.pp
+++ b/manifests/app/wordpress.pp
@@ -58,7 +58,7 @@ define uhosting::app::wordpress (
 
   include uhosting::profiles::php
   include uhosting::profiles::supervisord
-  $fpm_socket = "/var/lib/uhosting/php5-fpm-${name}.sock"
+  $fpm_socket = "/var/lib/uhosting/php5.5-fpm-${name}.sock"
 
   # PHP-FPM pool
   $_php_values = {
@@ -159,9 +159,9 @@ define uhosting::app::wordpress (
 
   ## Pre-requisits
 
-  #ensure_packages([ 'php5-curl',
-  #                  'php5-apcu',
-  #                  'php5-gd'])
+  #ensure_packages([ 'php5.5-curl',
+  #                  'php5.5-apcu',
+  #                  'php5.5-gd'])
 
 
 }

--- a/manifests/profiles/php.pp
+++ b/manifests/profiles/php.pp
@@ -22,27 +22,25 @@ class uhosting::profiles::php (
     }
   }
 
-  $_version_repo = $php_version ? {
-    '5.4' => 'ondrej/php5-oldstable',
-    '5.5' => 'ondrej/php5',
-    '5.6' => 'ondrej/php5-5.6',
-    '7.0' => 'ondrej/php',
-  }
+  #package { 'php5-common':
+  #  ensure  => 'absent',
+  #}
+  #package { 'php5-json':
+  #  ensure  => 'absent',
+  #}
+
+  $_version_repo = 'ondrej/php'
+  $package_prefix = "php${php_version}-"
+  $cfg_root = "/etc/php/${php_version}"
+  $config_root_ini = "/etc/php/${php_version}"
+  $fpm_service_name = "php${php_version}-fpm"
 
   if $php_version == '7.0' {
-    $config_root_ini = '/etc/php/7.0'
     $ext_tool_enable = '/usr/sbin/phpenmod'
     $ext_tool_query = '/usr/sbin/phpquery'
-    $package_prefix = 'php7.0-'
-    $fpm_service_name = 'php7.0-fpm'
-    $cfg_root = '/etc/php/7.0'
   } else {
-    $config_root_ini = undef
     $ext_tool_enable = undef
     $ext_tool_query = undef
-    $package_prefix = undef
-    $fpm_service_name = undef
-    $cfg_root = undef
   }
 
   apt::source { 'sury_php_ppa':

--- a/manifests/profiles/php.pp
+++ b/manifests/profiles/php.pp
@@ -22,13 +22,6 @@ class uhosting::profiles::php (
     }
   }
 
-  #package { 'php5-common':
-  #  ensure  => 'absent',
-  #}
-  #package { 'php5-json':
-  #  ensure  => 'absent',
-  #}
-
   $_version_repo = 'ondrej/php'
   $package_prefix = "php${php_version}-"
   $cfg_root = "/etc/php/${php_version}"

--- a/manifests/resources/phpfpm_pool.pp
+++ b/manifests/resources/phpfpm_pool.pp
@@ -38,24 +38,8 @@ define uhosting::resources::phpfpm_pool (
   if $php_values { validate_hash($php_values) }
   if $env_variables { validate_hash($env_variables) }
 
-  case $php_version {
-    '5.4': {
-      $_fpm_binary = '/usr/sbin/php5-fpm'
-      $_master_config_file = "/etc/php5/fpm/${name}.conf"
-    }
-    '5.5': {
-      $_fpm_binary = '/usr/sbin/php5-fpm'
-      $_master_config_file = "/etc/php5/fpm/${name}.conf"
-    }
-    '5.6': {
-      $_fpm_binary = '/usr/sbin/php5-fpm'
-      $_master_config_file = "/etc/php5/fpm/${name}.conf"
-    }
-    '7.0': {
-      $_fpm_binary = '/usr/sbin/php-fpm7.0'
-      $_master_config_file = "/etc/php/7.0/fpm/${name}.conf"
-    }
-  }
+  $_fpm_binary = "/usr/sbin/php-fpm${php_version}"
+  $_master_config_file = "/etc/php/${php_version}/fpm/${name}.conf"
 
   $ensure_process = $ensure ? {
     'present' => 'running',

--- a/manifests/resources/site.pp
+++ b/manifests/resources/site.pp
@@ -383,7 +383,7 @@ define uhosting::resources::site (
         include uhosting::profiles::nginx
         include uhosting::profiles::supervisord
         include uhosting::profiles::php
-        $fpm_socket = "${socket_path}/php5-fpm-${name}.sock"
+        $fpm_socket = "${socket_path}/php${uhosting::profiles::php::php_version}-fpm-${name}.sock"
         $vhost_defaults = {
           index_files => [ 'index.php' ],
           try_files   => [ '$uri', '$uri/', '=404' ],


### PR DESCRIPTION
The new repo has new package names (e.g. php5.5-fpm instead of php5-fpm), requiring some changes. The new version should be compatible with existing installation (existing hieradata), although some special measures had to be taken, which will eventually get removed.
